### PR TITLE
fix silent failure

### DIFF
--- a/whois.go
+++ b/whois.go
@@ -62,11 +62,6 @@ func (c *Client) SetAbsoluteTimeout(enabled bool) *Client {
 	return c
 }
 
-type hasTimeout struct {
-	Timeout time.Duration
-	proxy.Dialer
-}
-
 // Version returns package version
 func Version() string {
 	return "1.15.6"
@@ -105,7 +100,7 @@ func (c *Client) SetDialer(dialer proxy.Dialer) *Client {
 
 // SetTimeout set query timeout
 func (c *Client) SetTimeout(timeout time.Duration) *Client {
-	if d, ok := c.dialer.(*hasTimeout); ok {
+	if d, ok := c.dialer.(*net.Dialer); ok {
 		d.Timeout = timeout
 	}
 	c.timeout = timeout


### PR DESCRIPTION
`hasTimeout` was never used, so in `SetTimeout` we would never have hit out type assertion, which means we would be using the Dialer would continue to use the default timeout of 30s

```
// NewClient returns new whois client
func NewClient() *Client {
	return &Client{
		dialer: &net.Dialer{
			Timeout: defaultTimeout,
		},
		timeout: defaultTimeout,
	}
}
```
- update type assertion
- delete dead code `hasTimeout`